### PR TITLE
This is a minimal implementation of visible block timestamps.

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2415,9 +2415,9 @@
 ;;; Block timestamps
 
 ;;; TODO should be customizable
-;;; TODO omit day on journal pages (optionally)
-;;; TODO option to also shore created-at time
+;;; TODO option to also show created-at time
 (def ts-formatter (tf/formatter "M-d-YY H:mm"))
+(def ts-formatter-journal (tf/formatter "H:mm"))
 
 ;;; Similar to cljs-time.coerce/from-long but respects local timezone
 (defn time-from-long
@@ -2433,7 +2433,10 @@
        :on-click (fn [e]
                    (prn :toggle-timestamps) ;TODO!
                    )}
-      (tf/unparse ts-formatter (time-from-long timestamp))
+      (tf/unparse (if (:block/journal-day (:block/page block))
+                    ts-formatter-journal
+                    ts-formatter)
+                  (time-from-long timestamp))
       ]]))
 
 (rum/defcs block-content-or-editor < rum/reactive

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2417,7 +2417,7 @@
 ;;; TODO should be customizable
 ;;; TODO option to also show created-at time
 (def ts-formatter (tf/formatter "M-d-YY H:mm"))
-(def ts-formatter-journal (tf/formatter "H:mm"))
+(def ts-formatter-journal (tf/formatter "h:mm"))
 
 ;;; Similar to cljs-time.coerce/from-long but respects local timezone
 (defn time-from-long

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -15,7 +15,10 @@
             [frontend.util.text :as text-util]
             [goog.object :as gobj]
             [reitit.frontend.easy :as rfe]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [cljs-time.core :as t]
+            [cljs-time.format :as tf]
+            ))
 
 (rum/defc blocks-cp < rum/reactive db-mixins/query
   {}
@@ -53,7 +56,15 @@
                          :page))
                       (.preventDefault e)))}
        [:h1.title
-        (gp-util/capitalize-all title)]]
+        (gp-util/capitalize-all title)
+        ;; Add day of week.
+        ;; TODO place under option, maybe with formatting control
+        [:span.font-light.opacity-50 
+         " "
+         (tf/unparse (tf/formatter "EEEE")
+                     (date/journal-day->real-ts (:block/journal-day page-entity)))
+         ]
+        ]]
 
       (if today?
         (blocks-cp repo page)

--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -181,6 +181,12 @@
    journal-title
    (date-time-util/safe-journal-title-formatters (state/get-date-formatter))))
 
+(defn journal-day->real-ts
+  "journal-day format yyyyMMdd"
+  [day]
+  (when day
+    (tf/parse (tf/formatter "yyyyMMdd") (str day))))
+
 (defn journal-day->ts
   "journal-day format yyyyMMdd"
   [day]


### PR DESCRIPTION
Not ready for primetime, see TODOs

<img width="823" alt="image" src="https://github.com/logseq/logseq/assets/19027/9463f0e6-b80d-46c4-99e7-8a4c691dc3ef">

Also in here: adding Day-of-week to journal titles. Nothing technically to do with each other, but they both make time more visible.

<img width="653" alt="image" src="https://github.com/mtravers/logseq/assets/19027/10a36e59-bdf6-4851-ba14-5692f1c0b47c">
